### PR TITLE
increased timeouts for longer grating change time

### DIFF
--- a/python/lsst/ts/atmonochromator/model.py
+++ b/python/lsst/ts/atmonochromator/model.py
@@ -33,8 +33,8 @@ class Model:
 
         self.connection_timeout = 10.0
         self.read_timeout = 10.0
-        self.move_timeout = 60.0
-        self.move_grating_timeout = 300
+        self.move_timeout = 120.0
+        self.move_grating_timeout = 500
 
         self.wait_ready_sleeptime = 0.5
 


### PR DESCRIPTION
The grating change takes longer than expected. The timeouts are defined in `model.py`. I increased both `move_timeout` and 'move_grating_timeout'.